### PR TITLE
Deal with empty meta-data header

### DIFF
--- a/@gifti/save.m
+++ b/@gifti/save.m
@@ -188,6 +188,9 @@ for i=1:length(this.data)
         fprintf(fid,'%s<MD>\n',o(3));
         fprintf(fid,'%s<Name><![CDATA[%s]]></Name>\n',o(4),...
             this.data{i}.metadata(j).name);
+        if isempty(this.data{i}.metadata(j).value)
+            this.data{i}.metadata(j).value = 0;
+        end
         fprintf(fid,'%s<Value><![CDATA[%s]]></Value>\n',o(4),...
             this.data{i}.metadata(j).value);
         fprintf(fid,'%s</MD>\n',o(3));


### PR DESCRIPTION
I ran into this problem running FSL's PALM. It seems that this is not a problem with PALM116 and Octave, but PALM119 and Matlab (2020b) fail when `fprintf` runs into an empty cell.

I can upload files and commands that fail if you'd like to see the problem